### PR TITLE
Js fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     </scm>
 
     <properties>
-        <tapestry-release-version>5.4-beta-4</tapestry-release-version>
+	    <tapestry-release-version>5.4.0</tapestry-release-version>
     </properties>
 
     <repositories>
@@ -46,11 +46,6 @@
             <url>http://repository.apache.org/snapshots</url>
         </repository>
 
-        <!-- TODO: remove when 5.4 hits central -->
-        <repository>
-            <id>apache-staging</id>
-            <url>https://repository.apache.org/content/groups/staging/</url>
-        </repository>
         <repository>
             <id>apache-snapshots2</id>
             <url>https://repository.apache.org/content/groups/public</url>

--- a/src/main/java/be/eliwan/tapestry5/high/components/Highcharts.java
+++ b/src/main/java/be/eliwan/tapestry5/high/components/Highcharts.java
@@ -92,20 +92,6 @@ public class Highcharts implements ClientElement {
 
         opt.put("opt", params);
 
-        javascript.addModuleConfigurationCallback(new ModuleConfigurationCallback() {
-            @Override
-            public JSONObject configure(JSONObject configuration) {
-                // see http://stackoverflow.com/questions/8186027/loading-highcharts-with-require-js
-                final JSONArray highchartsShim = new JSONArray();
-                highchartsShim.put(new JSONObject("exports", "Highcharts"));
-                highchartsShim.put(new JSONObject("deps", new JSONArray().put("jquery")));
-                configuration.in("shim").put("highcharts", highchartsShim);
-                // this supposes the highstock stack only has one javascript library
-                configuration.in("paths").put("highcharts", highchartsStack.getJavaScriptLibraries().get(0).toClientURL());
-                return configuration;
-            }
-        });
-        
         javascript.require("high/highcharts").with(opt);
     }
 

--- a/src/main/java/be/eliwan/tapestry5/high/components/Highcharts.java
+++ b/src/main/java/be/eliwan/tapestry5/high/components/Highcharts.java
@@ -129,4 +129,10 @@ public class Highcharts implements ClientElement {
         return null == options;
     }
 
+	@Override
+	public String getClientId()
+	{
+		return clientId;
+	}
+
 }

--- a/src/main/java/be/eliwan/tapestry5/high/components/Highstock.java
+++ b/src/main/java/be/eliwan/tapestry5/high/components/Highstock.java
@@ -130,4 +130,10 @@ public class Highstock implements ClientElement {
         return null == options;
     }
 
+	@Override
+	public String getClientId()
+	{
+		return clientId;
+	}
+
 }

--- a/src/main/java/be/eliwan/tapestry5/high/services/HighchartsStack.java
+++ b/src/main/java/be/eliwan/tapestry5/high/services/HighchartsStack.java
@@ -77,7 +77,7 @@ public class HighchartsStack implements JavaScriptStack {
 
     @Override
     public String getInitialization() {
-        return productionMode ? null : "Tapestry.DEBUG_ENABLED = true;";
+        return null;
     }
 
     @Override

--- a/src/main/java/be/eliwan/tapestry5/high/services/HighchartsStack.java
+++ b/src/main/java/be/eliwan/tapestry5/high/services/HighchartsStack.java
@@ -15,6 +15,7 @@ import org.apache.tapestry5.func.Mapper;
 import org.apache.tapestry5.ioc.annotations.Symbol;
 import org.apache.tapestry5.ioc.internal.util.CollectionFactory;
 import org.apache.tapestry5.services.AssetSource;
+import org.apache.tapestry5.services.javascript.JavaScriptAggregationStrategy;
 import org.apache.tapestry5.services.javascript.JavaScriptStack;
 import org.apache.tapestry5.services.javascript.StylesheetLink;
 
@@ -53,7 +54,8 @@ public class HighchartsStack implements JavaScriptStack {
 
         final Mapper<String, Asset> pathToAsset = new Mapper<String, Asset>() {
 
-            public Asset map(String path) {
+            @Override
+			public Asset map(String path) {
                 return assetSource.getExpandedAsset(path);
             }
         };
@@ -97,4 +99,10 @@ public class HighchartsStack implements JavaScriptStack {
     public List<String> getModules() {
         return modules;
     }
+
+	@Override
+	public JavaScriptAggregationStrategy getJavaScriptAggregationStrategy()
+	{
+		return JavaScriptAggregationStrategy.COMBINE_AND_MINIMIZE;
+	}
 }

--- a/src/main/java/be/eliwan/tapestry5/high/services/HighstockStack.java
+++ b/src/main/java/be/eliwan/tapestry5/high/services/HighstockStack.java
@@ -77,7 +77,7 @@ public class HighstockStack implements JavaScriptStack {
 
     @Override
     public String getInitialization() {
-        return productionMode ? null : "Tapestry.DEBUG_ENABLED = true;";
+        return null;
     }
 
     @Override

--- a/src/main/java/be/eliwan/tapestry5/high/services/HighstockStack.java
+++ b/src/main/java/be/eliwan/tapestry5/high/services/HighstockStack.java
@@ -15,6 +15,7 @@ import org.apache.tapestry5.func.Mapper;
 import org.apache.tapestry5.ioc.annotations.Symbol;
 import org.apache.tapestry5.ioc.internal.util.CollectionFactory;
 import org.apache.tapestry5.services.AssetSource;
+import org.apache.tapestry5.services.javascript.JavaScriptAggregationStrategy;
 import org.apache.tapestry5.services.javascript.JavaScriptStack;
 import org.apache.tapestry5.services.javascript.StylesheetLink;
 
@@ -53,7 +54,8 @@ public class HighstockStack implements JavaScriptStack {
 
         final Mapper<String, Asset> pathToAsset = new Mapper<String, Asset>() {
 
-            public Asset map(String path) {
+            @Override
+			public Asset map(String path) {
                 return assetSource.getExpandedAsset(path);
             }
         };
@@ -97,4 +99,10 @@ public class HighstockStack implements JavaScriptStack {
     public List<String> getModules() {
         return modules;
     }
+
+	@Override
+	public JavaScriptAggregationStrategy getJavaScriptAggregationStrategy()
+	{
+		return JavaScriptAggregationStrategy.COMBINE_AND_MINIMIZE;
+	}
 }

--- a/src/main/resources/META-INF/modules/high/highcharts.js
+++ b/src/main/resources/META-INF/modules/high/highcharts.js
@@ -1,3 +1,12 @@
+require.config({
+	shim : {
+		highcharts : {
+			exports : "Highcharts",
+			deps : [ "jquery" ]
+		}
+	}
+});
+
 define(["jquery", "t5/core/console"], function($, console) {
 	return function(spec) {
 		var params = {};

--- a/src/main/resources/META-INF/modules/high/highstock.js
+++ b/src/main/resources/META-INF/modules/high/highstock.js
@@ -1,3 +1,11 @@
+require.config({
+	shim : {
+		highcharts : {
+			exports : "Highcharts",
+			deps : [ "jquery" ]
+		}
+	}
+});
 define(["jquery", "t5/core/console"], function($, console) {
 	return function(spec) {
         var params = {};


### PR DESCRIPTION
Returning ""Tapestry.DEBUG_ENABLED = true" caused exception in browser console. Due to Tapestry 5.4 documentation, "getInitialization" method is depricated but it can return null. 